### PR TITLE
Adding limit to table size for Excel

### DIFF
--- a/src/python/pyqe/_pyqe.py
+++ b/src/python/pyqe/_pyqe.py
@@ -223,9 +223,17 @@ def send_workflowresult_to_sql(workflowresult, csv=False, excel=False):
                 else:
                     df_to_write = dfs[table_name]
 
-                df_to_write.to_excel(
-                    writer, sheet_name=_compress_name(table_name), index=True
-                )
+                # Excel only allows up to about a million rows...
+                if len(df_to_write.index) > 1048576:
+                    print(
+                        "Table {} has more than 1048576 rows and cannot be written to Excel worksheet: it has been dropped.".format(
+                            table_name
+                        )
+                    )
+                else:
+                    df_to_write.to_excel(
+                        writer, sheet_name=_compress_name(table_name), index=True
+                    )
     elif csv:
         if not os.path.isdir("./csv_data"):
             os.mkdir("./csv_data")


### PR DESCRIPTION
Excel worksheet cannot have more than about a million rows. When a table above this size is created, I now drop it instead of entirely failing to write the file.