### PR TITLE
Correcting Excel export bug that erases sheets

### DIFF
--- a/src/python/pyqe/_pyqe.py
+++ b/src/python/pyqe/_pyqe.py
@@ -223,9 +223,17 @@ def send_workflowresult_to_sql(workflowresult, csv=False, excel=False):
                 else:
                     df_to_write = dfs[table_name]
 
-                df_to_write.to_excel(
-                    writer, sheet_name=_compress_name(table_name), index=True
-                )
+                # Excel only allows up to about a million rows...
+                if len(df_to_write.index) > 1048576:
+                    print(
+                        "Table {} has more than 1048576 rows and cannot be written to Excel worksheet: it has been dropped.".format(
+                            table_name
+                        )
+                    )
+                else:
+                    df_to_write.to_excel(
+                        writer, sheet_name=_compress_name(table_name), index=True
+                    )
             # Loop over sheets that are not in the current json
             # Ensures they are also written to the new Excel file
             compressed_table_names = [_compress_name(x) for x in dfs.keys()]


### PR DESCRIPTION
When exporting a JSON to excel that does NOT contain one of the sheets in the original Excel file, that sheet is not present in the new Excel file.

This PR corrects this dumb behavior.