### PR TITLE
Table name truncation in Postgres

### DIFF
--- a/src/python/pyqe/_pyqe.py
+++ b/src/python/pyqe/_pyqe.py
@@ -165,25 +165,26 @@ def extract_dataframes(workflowresult):
     return dfs
 
 
-def _compress_name(original_name):
-    """Compresses a table name to less than 31 characters so that it is 
-    suitable for an Excel sheet.
+def _compress_name(original_name, length):
+    """Compresses a table name to less than length characters so that it is 
+    suitable for Excel/Postgres limitations.
 
     Args:
         original_name (str): The original table name to compress
+        length (int): The maximum length of a name
     Returns:
-        compressed_name (str): A new name that fits on 31 characters
+        compressed_name (str): A new name that fits the length
     """
 
-    if len(original_name) > 31:
+    if len(original_name) > length:
         compressed_name = re.sub("zapata-v1", "zv1", original_name)
     else:
         return original_name
 
-    if len(compressed_name) > 31:
+    if len(compressed_name) > length:
         compressed_name = re.sub("[aeiouy]", "", compressed_name)
-    if len(compressed_name) > 31:
-        compressed_name = compressed_name[:31]
+    if len(compressed_name) > length:
+        compressed_name = compressed_name[:length]
 
     return compressed_name
 
@@ -203,6 +204,9 @@ def send_workflowresult_to_sql(workflowresult, csv=False, excel=False):
         print(
             "Excel and csv exports both specified, only excel export will be performed."
         )
+    
+    max_len_excel = 31
+    max_len_postgres = 63
 
     dfs = extract_dataframes(workflowresult)
     if excel:
@@ -215,9 +219,9 @@ def send_workflowresult_to_sql(workflowresult, csv=False, excel=False):
             for table_name in dfs:
                 if (
                     excel_file is not None
-                    and _compress_name(table_name) in excel_file.sheet_names
+                    and _compress_name(table_name, max_len_excel) in excel_file.sheet_names
                 ):
-                    old_df = excel_file.parse(_compress_name(table_name))
+                    old_df = excel_file.parse(_compress_name(table_name, max_len_excel))
                     old_df.set_index("_id", inplace=True)
                     df_to_write = old_df.append(dfs[table_name], ignore_index=False)
                 else:
@@ -232,11 +236,11 @@ def send_workflowresult_to_sql(workflowresult, csv=False, excel=False):
                     )
                 else:
                     df_to_write.to_excel(
-                        writer, sheet_name=_compress_name(table_name), index=True
+                        writer, sheet_name=_compress_name(table_name, max_len_excel), index=True
                     )
             # Loop over sheets that are not in the current json
             # Ensures they are also written to the new Excel file
-            compressed_table_names = [_compress_name(x) for x in dfs.keys()]
+            compressed_table_names = [_compress_name(x, max_len_excel) for x in dfs.keys()]
             for sheet_name in excel_file.sheet_names:
                 if sheet_name not in compressed_table_names:
                     transferred_df = excel_file.parse(sheet_name)
@@ -259,4 +263,4 @@ def send_workflowresult_to_sql(workflowresult, csv=False, excel=False):
     else:
         engine = create_engine(get_db_conn_str())
         for table_name in dfs:
-            dfs[table_name].to_sql(table_name[:63], con=engine, if_exists="append")
+            dfs[table_name].to_sql(_compress_name(table_name, max_len_postgres), con=engine, if_exists="append")


### PR DESCRIPTION
Added a "smart" truncation of table names in Postgres: eliminates all vowels before cutting off excess letters to avoid the 63-characters limit for table names.